### PR TITLE
feat: AKS score breakdown, merged assessment panel, UI improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # az-scout-plugin-aks-placement-advisor
 
-AKS Placement Advisor plugin for [az-scout](https://github.com/az-scout/az-scout) — evaluates and recommends VM SKUs for AKS node pools with heuristic scoring.
+AKS Placement Advisor plugin for [az-scout](https://github.com/az-scout/az-scout) — evaluates and recommends VM SKUs for AKS node pools with heuristic scoring, AKS eligibility checks, pricing data, and deployment confidence scoring.
 
 ## Purpose
 
@@ -8,9 +8,11 @@ This plugin helps answer:
 
 - Which VM SKUs are accepted by AKS for node pools in a given region?
 - Which SKUs have availability zone support without restrictions?
+- Is a SKU eligible for system or user node pools?
 - Are quotas sufficient for the selected SKU family?
+- What is the estimated cost (pay-as-you-go and spot pricing)?
+- What is the deployment confidence level for a SKU in a specific region?
 - What fallback SKUs should be considered?
-- What is the confidence level for deploying a SKU in a specific region?
 
 This is a **decision-support tool**, not a real-time capacity guarantee tool.
 
@@ -18,7 +20,7 @@ This is a **decision-support tool**, not a real-time capacity guarantee tool.
 
 ### Data Sources
 
-The plugin combines three Azure APIs to build recommendations:
+The plugin combines multiple Azure APIs and enrichment stages to build recommendations:
 
 ```
 ┌─────────────────────────┐
@@ -33,28 +35,88 @@ The plugin combines three Azure APIs to build recommendations:
             ▼
 ┌─────────────────────────┐
 │  Compute Usages API     │  Enrichment — vCPU quota per family
-│  (Microsoft.Compute)    │  Shows remaining quota, warns if insufficient
+│  (Microsoft.Compute)    │  Shows remaining/used/limit quota, warns if insufficient
 └───────────┬─────────────┘
             ▼
 ┌─────────────────────────┐
-│  Scoring Engine         │  Heuristic score 0–100 per SKU
-│  (scoring.py)           │  → confidence: high / medium / low
+│  Pricing API            │  Enrichment — pay-as-you-go and spot prices
+│                         │  Adds per-hour cost estimates
+└───────────┬─────────────┘
+            ▼
+┌─────────────────────────┐
+│  AKS Eligibility Filter │  System vs user pool eligibility (3-state)
+│  (_aks_filter.py)       │  → eligible / warning / ineligible
+└───────────┬─────────────┘
+            ▼
+┌─────────────────────────┐
+│  Heuristic Scoring      │  Score 0–100 per SKU (scoring.py)
+│                         │  → confidence: high / medium / low
+└───────────┬─────────────┘
+            ▼
+┌─────────────────────────┐
+│  Deployment Confidence  │  Weighted score from quota pressure, zone breadth,
+│  (az-scout core)        │  restriction density, and price pressure
 └─────────────────────────┘
 ```
 
-1. **AKS VM SKUs API** (`Microsoft.ContainerService/locations/{location}/vmSkus`, preview) — returns all VM SKUs accepted by AKS for node pool creation. Every SKU in this list is confirmed AKS-compatible.
+1. **AKS VM SKUs API** (`Microsoft.ContainerService/locations/{location}/vmSkus`, `2026-01-02-preview`) — returns all VM SKUs accepted by AKS for node pool creation. Every SKU in this list is confirmed AKS-compatible.
 
 2. **Compute Resource SKUs API** (`Microsoft.Compute/skus`) — provides per-subscription zone restrictions. A SKU may be listed as available in zones 1, 2, 3 by the AKS API, but restricted in zones 1 and 3 for your specific subscription. The plugin merges these restrictions and removes unavailable zones.
 
-3. **Compute Usages API** (`Microsoft.Compute/locations/{location}/usages`) — provides remaining vCPU quota per SKU family. If your subscription has 12 vCPUs remaining for `standardDSv5Family` and the SKU needs 8, you get a warning.
+3. **Compute Usages API** (`Microsoft.Compute/locations/{location}/usages`) — provides remaining, used, and limit vCPU quota per SKU family.
+
+4. **Pricing enrichment** — adds pay-as-you-go and spot pricing per SKU.
+
+5. **Deployment Confidence** (from az-scout core) — a weighted score combining quota pressure, zone breadth, restriction density, and price pressure signals.
 
 ### Capability Normalisation
 
 The AKS API returns capability names in camelCase (`memoryGB`, `premiumIO`) while the Compute API uses PascalCase (`MemoryGB`, `PremiumIO`). The plugin normalises all keys to PascalCase internally.
 
+## AKS Eligibility Rules
+
+Each SKU is checked for AKS node pool eligibility with a 3-state result: **eligible**, **warning**, or **ineligible**. Rules differ by pool type.
+
+### System Node Pools
+
+**Ineligible** (blocking):
+- A-series VMs
+- B-series (burstable) VMs
+- Promo/Preview SKUs
+- < 2 vCPUs or < 4 GB RAM
+- No Premium Storage (PremiumIO)
+- No availability zones
+
+**Warning** (non-blocking):
+- No Accelerated Networking
+- No Ephemeral OS Disk support
+- Gen1-only / Trusted Launch unavailable
+- No host encryption support
+- Zone restrictions in the region
+
+### User Node Pools
+
+**Ineligible** (blocking):
+- A-series VMs
+- Promo/Preview SKUs
+- < 2 vCPUs
+- No availability zones
+
+**Warning** (non-blocking):
+- B-series (CPU credit exhaustion risk)
+- No Premium Storage
+- No Accelerated Networking
+- No Ephemeral OS Disk support
+- Gen1-only / Trusted Launch unavailable
+- No host encryption support
+- Not Spot-capable
+- ARM64 architecture (image compatibility)
+- Low memory (< 4 GB)
+- Zone restrictions
+
 ## Scoring Model
 
-Each SKU receives a score from 0 to 100, computed as a sum of bonuses and penalties:
+Each SKU receives a heuristic score from 0 to 100, computed as a sum of bonuses and penalties:
 
 ### Score Components
 
@@ -85,14 +147,16 @@ Each SKU receives a score from 0 to 100, computed as a sum of bonuses and penalt
 | 50 – 74 | **medium** | Usable but with caveats (partial zones, missing quota data) |
 | < 50 | **low** | Significant issues — restrictions, no zones, unsuitable family |
 
-### Example Scenarios
+## Deployment Confidence
 
-| SKU | Zones | Restrictions | Quota | Score | Confidence |
-|-----|-------|-------------|-------|-------|------------|
-| Standard_D4s_v6 | 1, 2, 3 | None | OK | **100** | high |
-| Standard_D4s_v5 | ~~1, 2, 3~~ (all restricted) | All zones | OK | **50** | medium |
-| Standard_B2s | (none) | None | OK | **60** | medium |
-| Standard_L8s_v2 | 1, 2, 3 | None | OK | **55** | medium |
+In addition to the heuristic score, each SKU receives a **deployment confidence** score (0–100) from the az-scout core scoring engine. This uses weighted signals:
+
+| Signal | Weight | Description |
+|--------|--------|-------------|
+| Quota Pressure | 38.5% | Non-linear penalty when family vCPU usage exceeds 80% |
+| Zone Breadth | 23.1% | Available zones out of 3 (unrestricted) |
+| Restriction Density | 23.1% | Fraction of zones without restrictions |
+| Price Pressure | 15.4% | Spot-to-PAYGO ratio (lower = better savings potential) |
 
 ## Limitations
 
@@ -100,6 +164,7 @@ Each SKU receives a score from 0 to 100, computed as a sum of bonuses and penalt
 - **Zone restrictions reflect subscription-level constraints**, not real-time capacity. A zone may be unrestricted but temporarily out of stock.
 - **The AKS VM SKUs API is a preview API** (`2026-01-02-preview`). Behaviour may change.
 - **Quota data depends on `subscription_id`** being provided. Without it, quota enrichment is skipped.
+- **Pricing and deployment confidence enrichment** are best-effort — failures are logged and the pipeline continues without them.
 - **No real-time capacity signal.** No Azure public API exposes VM stock levels.
 
 ## Available Routes
@@ -117,14 +182,15 @@ All routes are mounted under `/plugins/aks-placement-advisor/`.
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `region` | string | **yes** | — | Azure region name (e.g. `westeurope`) |
-| `subscription_id` | string | **yes** | — | Azure subscription ID |
-| `tenant_id` | string | no | — | Azure tenant ID |
+| `subscriptionId` | string | no | — | Azure subscription ID (required for API calls) |
+| `tenantId` | string | no | — | Azure tenant ID |
 | `require_zones` | bool | no | `false` | Only return SKUs with zone support |
 | `require_vmss` | bool | no | `true` | Include VMSS bonus in scoring |
 | `min_vcpus` | int | no | — | Minimum vCPU count filter |
 | `min_memory_gb` | float | no | — | Minimum memory in GB filter |
 | `sku_name_filter` | string | no | — | Substring filter on SKU name |
-| `max_results` | int | no | `20` | Maximum results (1–200) |
+| `max_results` | int | no | `0` (all) | Maximum results (0–2000, 0 = no limit) |
+| `pool_type` | string | no | `system` | Node pool type: `system` or `user` |
 
 ### Response Shape
 
@@ -146,14 +212,43 @@ All routes are mounted under `/plugins/aks-placement-advisor/`.
       "vmssSupported": true,
       "aksCompatible": true,
       "quotaAvailable": 80,
+      "quotaLimit": 100,
+      "quotaUsed": 20,
       "score": 100.0,
       "confidence": "high",
       "warnings": [],
-      "fallbackSkus": ["Standard_D8s_v6", "Standard_D2s_v6"]
+      "fallbackSkus": ["Standard_D8s_v6", "Standard_D2s_v6"],
+      "aks": {
+        "status": "eligible",
+        "eligible": true,
+        "pool_type": "system",
+        "errors": [],
+        "warnings": []
+      },
+      "pricing": {
+        "paygo": 0.192,
+        "spot": 0.038,
+        "currency": "USD"
+      },
+      "deploymentConfidence": {
+        "score": 92.0,
+        "label": "high",
+        "signals": {}
+      }
     }
   ]
 }
 ```
+
+## Chat Mode
+
+The plugin registers an **AKS Advisor** chat mode that provides guided SKU recommendations through conversation. It automatically calls the MCP tools with appropriate filters and presents results as ranked tables with rationale.
+
+Suggested prompts:
+- "Find the best SKU for a 3-node system pool"
+- "What D-series SKUs are available in westeurope?"
+- "Compare westeurope vs northeurope for AKS"
+- "Recommend a GPU SKU for ML training"
 
 ## Available MCP Tools
 
@@ -168,6 +263,7 @@ All routes are mounted under `/plugins/aks-placement-advisor/`.
 recommend_aks_skus(
     region="westeurope",
     subscription_id="...",
+    tenant_id="...",
     require_zones=True,
     min_vcpus=4,
     min_memory_gb=8,
@@ -181,7 +277,9 @@ recommend_aks_skus(
 compare_aks_regions(
     regions=["westeurope", "northeurope", "francecentral"],
     subscription_id="...",
+    tenant_id="...",
     min_vcpus=4,
+    min_memory_gb=8,
 )
 ```
 
@@ -189,17 +287,20 @@ compare_aks_regions(
 
 ```
 src/az_scout_aks_placement_advisor/
-├── __init__.py       # Plugin class + module-level `plugin` instance
-├── models.py         # SkuRecommendation dataclass + DISCLAIMER
-├── scoring.py        # Heuristic scoring engine (score_sku, suggest_fallbacks)
-├── service.py        # Data pipeline: AKS API → Compute enrichment → scoring
-├── routes.py         # FastAPI routes (/health, /regions, /recommendations)
-├── tools.py          # MCP tools (recommend_aks_skus, compare_aks_regions)
+├── __init__.py        # Plugin class + module-level `plugin` instance
+├── _aks_filter.py     # AKS node pool eligibility rules (system vs user)
+├── chat_mode.py       # AKS Advisor chat mode definition
+├── models.py          # SkuRecommendation dataclass + DISCLAIMER
+├── scoring.py         # Heuristic scoring engine (score_sku, suggest_fallbacks)
+├── service.py         # Data pipeline: AKS API → enrichment → scoring
+├── routes.py          # FastAPI routes (/health, /regions, /recommendations)
+├── tools.py           # MCP tools (recommend_aks_skus, compare_aks_regions)
 └── static/
     ├── css/aks-placement-advisor.css
     ├── html/aks-placement-advisor-tab.html
     └── js/aks-placement-advisor-tab.js
 tests/
+├── test_aks_filter.py
 └── test_aks_placement_advisor.py
 ```
 
@@ -207,7 +308,7 @@ tests/
 
 ```bash
 # From the az-scout directory
-uv pip install -e ../az-scout-plugin-aks-sku-checker
+uv pip install -e ../az-scout-plugin-aks-placement-advisor
 ```
 
 The plugin is auto-discovered via the `az_scout.plugins` entry point.

--- a/src/az_scout_aks_placement_advisor/models.py
+++ b/src/az_scout_aks_placement_advisor/models.py
@@ -37,6 +37,8 @@ class SkuRecommendation:
     pricing_currency: str = "USD"
     # Deployment confidence (from enrich_skus_with_confidence)
     deployment_confidence: dict[str, object] | None = None
+    # AKS score breakdown (from scoring.score_sku)
+    score_breakdown: list[dict[str, object]] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, object]:
         """Serialise to a JSON-compatible dict with camelCase keys."""
@@ -56,6 +58,7 @@ class SkuRecommendation:
             "quotaUsed": self.quota_used,
             "score": self.score,
             "confidence": self.confidence,
+            "scoreBreakdown": self.score_breakdown,
             "warnings": self.warnings,
             "fallbackSkus": self.fallback_skus,
             "aks": {

--- a/src/az_scout_aks_placement_advisor/scoring.py
+++ b/src/az_scout_aks_placement_advisor/scoring.py
@@ -102,8 +102,8 @@ def score_sku(
     has_quota_data: bool = False,
     quota_remaining: int | None = None,
     vcpus: int = 0,
-) -> tuple[float, str, list[str]]:
-    """Compute a heuristic score, confidence bucket, and warnings list.
+) -> tuple[float, str, list[str], list[dict[str, object]]]:
+    """Compute a heuristic score, confidence bucket, warnings, and breakdown.
 
     Parameters
     ----------
@@ -122,28 +122,53 @@ def score_sku(
 
     Returns
     -------
-    tuple[float, str, list[str]]
-        ``(score, confidence, warnings)`` where score is 0–100,
-        confidence is ``"high"`` / ``"medium"`` / ``"low"``.
+    tuple[float, str, list[str], list[dict[str, object]]]
+        ``(score, confidence, warnings, breakdown)`` where score is 0–100,
+        confidence is ``"high"`` / ``"medium"`` / ``"low"``, and breakdown
+        is a list of ``{"label", "points", "applied"}`` dicts.
     """
     score = _BASE_SCORE
     warnings: list[str] = []
+    breakdown: list[dict[str, object]] = []
     capabilities = sku.get("capabilities", {})
     zones = sku.get("zones", [])
 
+    # --- Base score ---
+    breakdown.append({"label": "Base", "points": _BASE_SCORE, "applied": True})
+
     # --- Zone support ---
-    if zones:
+    has_zones = bool(zones)
+    if has_zones:
         score += _ZONE_BONUS
-        if len(zones) >= 3:
-            score += _MULTI_ZONE_BONUS
-    elif require_zones:
+    breakdown.append({"label": "Zone support", "points": _ZONE_BONUS, "applied": has_zones})
+
+    has_multi_zone = len(zones) >= 3
+    if has_multi_zone:
+        score += _MULTI_ZONE_BONUS
+    breakdown.append(
+        {
+            "label": "Multi-zone (\u22653)",
+            "points": _MULTI_ZONE_BONUS,
+            "applied": has_multi_zone,
+        }
+    )
+
+    if not has_zones and require_zones:
         score += _NO_ZONE_PENALTY
         warnings.append("Zone support required but not available for this SKU in this region")
+    breakdown.append(
+        {
+            "label": "No zones (required)",
+            "points": _NO_ZONE_PENALTY,
+            "applied": not has_zones and require_zones,
+        }
+    )
 
     # --- VMSS support ---
     # All SKUs returned by the AKS VM SKUs API support VMSS-based node pools.
     if require_vmss:
         score += _VMSS_BONUS
+    breakdown.append({"label": "VMSS support", "points": _VMSS_BONUS, "applied": require_vmss})
 
     # --- Capabilities richness ---
     caps_present = sum(
@@ -158,23 +183,49 @@ def score_sku(
         )
         if k in capabilities
     )
-    if caps_present >= 4:
+    rich_caps = caps_present >= 4
+    if rich_caps:
         score += _RICH_CAPS_BONUS
+    breakdown.append(
+        {
+            "label": "Rich capabilities",
+            "points": _RICH_CAPS_BONUS,
+            "applied": rich_caps,
+        }
+    )
 
     # --- Preferred family bonus ---
     sku_name = sku.get("name", "")
-    if any(sku_name.startswith(p) for p in _PREFERRED_PREFIXES):
+    preferred = any(sku_name.startswith(p) for p in _PREFERRED_PREFIXES)
+    if preferred:
         score += _PREFERRED_FAMILY_BONUS
+    breakdown.append(
+        {
+            "label": "Preferred family",
+            "points": _PREFERRED_FAMILY_BONUS,
+            "applied": preferred,
+        }
+    )
 
     # --- Restrictions penalty ---
-    if _has_zone_restriction(sku):
+    has_restriction = _has_zone_restriction(sku)
+    if has_restriction:
         score += _RESTRICTION_PENALTY
         warnings.append("SKU has zone-level restrictions in this region")
+    breakdown.append(
+        {
+            "label": "Zone restrictions",
+            "points": _RESTRICTION_PENALTY,
+            "applied": has_restriction,
+        }
+    )
 
     # --- Quota enrichment ---
+    quota_ok = False
     if has_quota_data:
         if quota_remaining is not None and quota_remaining >= vcpus:
             score += _QUOTA_BONUS
+            quota_ok = True
         elif quota_remaining is not None and quota_remaining < vcpus:
             warnings.append(
                 f"Insufficient quota: {quota_remaining} vCPUs remaining, "
@@ -182,12 +233,27 @@ def score_sku(
             )
     else:
         warnings.append("Quota data not available — provide subscription_id for enrichment")
+    breakdown.append(
+        {
+            "label": "Quota sufficient",
+            "points": _QUOTA_BONUS,
+            "applied": quota_ok,
+        }
+    )
 
     # --- Unsuitable family penalty ---
     family = sku.get("family", "")
-    if family in _UNSUITABLE_FAMILIES:
+    unsuitable = family in _UNSUITABLE_FAMILIES
+    if unsuitable:
         score += _UNSUITABLE_PENALTY
         warnings.append(f"SKU family '{family}' may not be suitable for general AKS workloads")
+    breakdown.append(
+        {
+            "label": "Unsuitable family",
+            "points": _UNSUITABLE_PENALTY,
+            "applied": unsuitable,
+        }
+    )
 
     # Clamp score to [0, 100]
     score = max(0.0, min(100.0, score))
@@ -200,7 +266,7 @@ def score_sku(
     else:
         confidence = "low"
 
-    return round(score, 1), confidence, warnings
+    return round(score, 1), confidence, warnings, breakdown
 
 
 # ---------------------------------------------------------------------------

--- a/src/az_scout_aks_placement_advisor/service.py
+++ b/src/az_scout_aks_placement_advisor/service.py
@@ -346,7 +346,7 @@ def get_recommendations(
         family = sku.get("family", "")
         quota_remaining = quota_map.get(family)
 
-        score_val, confidence, warnings = score_sku(
+        score_val, confidence, warnings, breakdown = score_sku(
             sku,
             require_zones=require_zones,
             require_vmss=require_vmss,
@@ -381,6 +381,7 @@ def get_recommendations(
             score=score_val,
             confidence=confidence,
             warnings=warnings,
+            score_breakdown=breakdown,
             fallback_skus=fallbacks,
             eligibility_status=eligibility.status,
             eligibility_errors=eligibility.errors,

--- a/src/az_scout_aks_placement_advisor/static/js/aks-placement-advisor-tab.js
+++ b/src/az_scout_aks_placement_advisor/static/js/aks-placement-advisor-tab.js
@@ -46,6 +46,8 @@
             confidence: rec.deploymentConfidence || null,
             heuristicScore: rec.score,
             heuristicConfidence: rec.confidence,
+            heuristicWarnings: rec.warnings || [],
+            scoreBreakdown: rec.scoreBreakdown || [],
             aks: rec.aks || {},
             fallbackSkus: rec.fallbackSkus || [],
         };
@@ -243,7 +245,7 @@
 
         // Build thead
         const headers = ["Status", "SKU Name", "Series", "vCPUs", "Memory (GB)",
-            "Quota Limit", "Quota Used", "Quota Rem.", "Confidence"];
+            "Quota Limit", "Quota Used", "Quota Rem.", "Confidence", "AKS Score"];
         if (showPricing) headers.push("PAYGO " + escapeHtml(priceCurrency) + "/h", "Spot " + escapeHtml(priceCurrency) + "/h");
         headers.push("Zones", "Issues");
 
@@ -282,7 +284,7 @@
                 }).join("");
             }
 
-            // Confidence badge — prefer deployment confidence, fall back to heuristic
+            // Deployment confidence badge (no fallback to heuristic)
             let confHtml = "\u2014";
             let confSort = -1;
             if (sku.confidence && sku.confidence.score != null) {
@@ -292,13 +294,18 @@
                 } else {
                     confHtml = escapeHtml(sku.confidence.score + " " + (sku.confidence.label || ""));
                 }
-            } else if (sku.heuristicScore != null) {
-                confSort = sku.heuristicScore;
+            }
+
+            // Heuristic score badge (separate column)
+            let scoreHtml = "\u2014";
+            let scoreSort = -1;
+            if (sku.heuristicScore != null) {
+                scoreSort = sku.heuristicScore;
                 const hConf = { score: sku.heuristicScore, label: sku.heuristicConfidence || "" };
                 if (C.renderConfidenceBadge) {
-                    confHtml = C.renderConfidenceBadge(hConf);
+                    scoreHtml = C.renderConfidenceBadge(hConf);
                 } else {
-                    confHtml = escapeHtml(sku.heuristicScore + " " + (sku.heuristicConfidence || ""));
+                    scoreHtml = escapeHtml(sku.heuristicScore + " " + (sku.heuristicConfidence || ""));
                 }
             }
 
@@ -316,6 +323,7 @@
             html += '<td>' + (quota.used != null ? quota.used : "\u2014") + '</td>';
             html += '<td>' + (quota.remaining != null ? quota.remaining : "\u2014") + '</td>';
             html += '<td data-sort="' + confSort + '">' + confHtml + '</td>';
+            html += '<td data-sort="' + scoreSort + '">' + scoreHtml + '</td>';
             if (showPricing) {
                 const pricing = sku.pricing || {};
                 html += '<td class="price-cell">' + (pricing.paygo != null ? formatNum(pricing.paygo, 4) : "\u2014") + '</td>';
@@ -343,13 +351,14 @@
         if (csvBtn) csvBtn.classList.remove("d-none");
 
         // Init Simple-DataTables for column sorting
-        // Cols: 0=Status, 1=Name, 2=Series, 3=vCPUs, 4=Memory, 5=QLimit, 6=QUsed, 7=QRem, 8=Confidence
+        // Cols: 0=Status, 1=Name, 2=Series, 3=vCPUs, 4=Memory, 5=QLimit, 6=QUsed, 7=QRem, 8=Confidence, 9=AKS Score
         const confCol = 8;
+        const scoreCol = 9;
         const colConfig = [
             { select: [3, 4, 5, 6, 7], type: "number" },
-            { select: confCol, type: "number" },
+            { select: [confCol, scoreCol], type: "number" },
         ];
-        let nextCol = confCol + 1;
+        let nextCol = scoreCol + 1;
         if (showPricing) {
             colConfig.push({ select: [nextCol, nextCol + 1], type: "number" });
             nextCol += 2;
@@ -365,14 +374,14 @@
         }
 
         // Build column filters using shared component
-        // Cols: 0=Status, 1=Name, 2=Series, 3=vCPUs, 4=Memory, 5=QLimit, 6=QUsed, 7=QRem, 8=Confidence
+        // Cols: 0=Status, 1=Name, 2=Series, 3=vCPUs, 4=Memory, 5=QLimit, 6=QUsed, 7=QRem, 8=Confidence, 9=AKS Score
         // Status (col 0) uses a custom <select> instead of text filter
-        const filterableCols = [1, 2, 3, 4, 5, 6, 7, 8];
-        const numericCols = new Set([3, 4, 5, 6, 7, 8]);
+        const filterableCols = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+        const numericCols = new Set([3, 4, 5, 6, 7, 8, 9]);
         if (showPricing) {
-            filterableCols.push(9, 10); // PAYGO, Spot
-            numericCols.add(9);
+            filterableCols.push(10, 11); // PAYGO, Spot
             numericCols.add(10);
+            numericCols.add(11);
         }
         if (C.buildColumnFilters) {
             const filterRow = C.buildColumnFilters(tableEl, filterableCols, numericCols);
@@ -408,11 +417,10 @@
             }
         }
 
-        // SKU detail click handler
-        tbody.querySelectorAll('[data-action="detail"]').forEach(function (btn) {
-            btn.addEventListener("click", function () {
-                openSkuDetail(btn.dataset.sku);
-            });
+        // SKU detail click handler (delegated so it survives DataTable re-renders)
+        tableEl.addEventListener("click", function (e) {
+            const btn = e.target.closest('[data-action="detail"]');
+            if (btn && btn.dataset.sku) openSkuDetail(btn.dataset.sku);
         });
 
     }
@@ -424,7 +432,7 @@
             region: el("region-select").value,
             subscriptionId: el("aks-sub-select").value,
             enrichedSku: enriched,
-            extraSections: function (_data, _enriched) {
+            prependSections: function (_data, _enriched) {
                 return _renderAksEligibilitySection(_enriched);
             },
         });
@@ -438,9 +446,12 @@
             warning: '<span class="badge bg-warning text-dark"><i class="bi bi-exclamation-triangle me-1"></i>Warning</span>',
             ineligible: '<span class="badge bg-danger"><i class="bi bi-x-circle me-1"></i>Ineligible</span>',
         };
+
         let body = '';
-        body += '<div class="vm-profile-row"><span class="vm-profile-label">Status</span><span>' + (statusBadges[aks.status] || "") + '</span></div>';
-        body += '<div class="vm-profile-row"><span class="vm-profile-label">Pool Type</span><span>' + escapeHtml(aks.pool_type || "") + '</span></div>';
+
+        // --- Eligibility ---
+        const poolLabel = aks.pool_type ? ' <span class="text-body-secondary small ms-2">(' + escapeHtml(aks.pool_type) + ' pool)</span>' : '';
+        body += '<div class="vm-profile-row"><span class="vm-profile-label">Status</span><span>' + (statusBadges[aks.status] || "") + poolLabel + '</span></div>';
         if (aks.errors && aks.errors.length) {
             aks.errors.forEach(function (e) {
                 body += '<div class="vm-profile-row"><span class="vm-profile-label text-danger">Error</span><span class="small">' + escapeHtml(e) + '</span></div>';
@@ -451,18 +462,64 @@
                 body += '<div class="vm-profile-row"><span class="vm-profile-label text-warning">Warning</span><span class="small">' + escapeHtml(w) + '</span></div>';
             });
         }
-        return _accordion("aksEligibility", "bi-gpu-card", "AKS Node Pool Eligibility", body);
+
+        // --- AKS Score ---
+        const score = enriched.heuristicScore;
+        if (score != null) {
+            let confBadgeHtml = "";
+            const hConf = { score: score, label: enriched.heuristicConfidence || "" };
+            if (C.renderConfidenceBadge) {
+                confBadgeHtml = C.renderConfidenceBadge(hConf);
+            } else {
+                confBadgeHtml = escapeHtml(score + " " + (enriched.heuristicConfidence || ""));
+            }
+            body += '<div class="vm-profile-row"><span class="vm-profile-label">AKS Score</span><span>' + confBadgeHtml + '</span></div>';
+
+            const breakdown = enriched.scoreBreakdown || [];
+            if (breakdown.length) {
+                body += '<div class="px-2 pt-1 pb-2 d-flex flex-wrap gap-1">';
+                for (const item of breakdown) {
+                    const pts = item.points;
+                    const applied = item.applied;
+                    const isBonus = pts > 0;
+                    const sign = isBonus ? "+" : "\u2212";
+                    const absVal = Math.abs(pts);
+                    if (applied) {
+                        const cls = isBonus ? 'bg-success bg-opacity-25 text-success-emphasis' : 'bg-danger bg-opacity-25 text-danger-emphasis';
+                        body += '<span class="badge ' + cls + '">';
+                        body += '<i class="bi ' + (isBonus ? 'bi-check-lg' : 'bi-x-lg') + ' me-1"></i>';
+                        body += escapeHtml(item.label) + ' ' + sign + escapeHtml(String(absVal));
+                        body += '</span>';
+                    } else {
+                        body += '<span class="badge bg-secondary bg-opacity-10 text-body-tertiary">';
+                        body += escapeHtml(item.label) + ' ' + sign + escapeHtml(String(absVal));
+                        body += '</span>';
+                    }
+                }
+                body += '</div>';
+            }
+
+            const warnings = enriched.heuristicWarnings || [];
+            if (warnings.length) {
+                warnings.forEach(function (w) {
+                    body += '<div class="vm-profile-row"><span class="vm-profile-label text-warning">Note</span><span class="small">' + escapeHtml(w) + '</span></div>';
+                });
+            }
+        }
+
+        return _accordion("aksAssessment", "bi-gpu-card", "AKS Assessment", body, true);
     }
 
     // Expose _accordion helper locally (mirrors shared component pattern)
-    function _accordion(id, icon, title, body) {
+    function _accordion(id, icon, title, body, expanded) {
+        const isOpen = expanded ? true : false;
         return '<div class="accordion mt-3" id="' + id + 'Accordion">' +
             '<div class="accordion-item">' +
             '<h2 class="accordion-header">' +
-            '<button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#' + id + 'Panel" aria-expanded="false">' +
+            '<button class="accordion-button' + (isOpen ? '' : ' collapsed') + '" type="button" data-bs-toggle="collapse" data-bs-target="#' + id + 'Panel" aria-expanded="' + isOpen + '">' +
             '<i class="bi ' + icon + ' me-2"></i>' + escapeHtml(title) +
             '</button></h2>' +
-            '<div id="' + id + 'Panel" class="accordion-collapse collapse">' +
+            '<div id="' + id + 'Panel" class="accordion-collapse collapse' + (isOpen ? ' show' : '') + '">' +
             '<div class="accordion-body p-2">' + body + '</div></div></div></div>';
     }
 
@@ -471,7 +528,7 @@
         if (!lastSkus) return;
         const rows = [["Status", "SKU", "Series", "vCPUs", "Memory (GB)",
             "Quota Limit", "Quota Used", "Quota Remaining",
-            "Confidence", "PAYGO/h", "Spot/h", "Zones", "Errors", "Warnings"]];
+            "Confidence", "AKS Score", "PAYGO/h", "Spot/h", "Zones", "Errors", "Warnings"]];
         for (const sku of lastSkus) {
             const aks = sku.aks || {};
             const caps = sku.capabilities || {};
@@ -479,12 +536,15 @@
             const pricing = sku.pricing || {};
             const conf = sku.confidence || {};
             rows.push([
-                aks.eligible ? "Eligible" : "Ineligible",
+                aks.status || "ineligible",
                 sku.name || "",
                 sku.series || "",
                 caps.vCPUs || "",
                 caps.MemoryGB || "",
+                quota.limit != null ? quota.limit : "",
+                quota.used != null ? quota.used : "",
                 quota.remaining != null ? quota.remaining : "",
+                conf.score != null ? conf.score + " (" + (conf.label || "") + ")" : "",
                 sku.heuristicScore != null ? sku.heuristicScore + " (" + (sku.heuristicConfidence || "") + ")" : "",
                 pricing.paygo != null ? pricing.paygo : "",
                 pricing.spot != null ? pricing.spot : "",

--- a/tests/test_aks_placement_advisor.py
+++ b/tests/test_aks_placement_advisor.py
@@ -343,27 +343,30 @@ class TestRecommendationsWithMock:
 class TestScoring:
     def test_high_confidence_sku(self) -> None:
         sku = SAMPLE_SKUS[0]  # Standard_D4s_v5 — zones, rich caps
-        score, confidence, warnings = score_sku(
+        score, confidence, warnings, breakdown = score_sku(
             sku, has_quota_data=True, quota_remaining=80, vcpus=4
         )
         assert score > 0
         assert confidence in ("high", "medium", "low")
         assert isinstance(warnings, list)
+        assert isinstance(breakdown, list)
+        assert len(breakdown) > 0
+        assert all("label" in b and "points" in b and "applied" in b for b in breakdown)
 
     def test_restricted_sku_penalised(self) -> None:
         sku = SAMPLE_SKUS[1]  # Standard_F4s_v2 — has restrictions
-        score_restricted, _, _ = score_sku(sku)
+        score_restricted, _, _, _ = score_sku(sku)
         sku_clean = {**sku, "restrictions": []}
-        score_clean, _, _ = score_sku(sku_clean)
+        score_clean, _, _, _ = score_sku(sku_clean)
         assert score_restricted < score_clean
 
     def test_no_zones_with_require_zones(self) -> None:
         sku = SAMPLE_SKUS[2]  # Standard_B2s — no zones
-        _, _, warnings = score_sku(sku, require_zones=True)
+        _, _, warnings, _ = score_sku(sku, require_zones=True)
         assert any("zone" in w.lower() for w in warnings)
 
     def test_score_clamped(self) -> None:
-        score, _, _ = score_sku(SAMPLE_SKUS[0])
+        score, _, _, _ = score_sku(SAMPLE_SKUS[0])
         assert 0 <= score <= 100
 
 


### PR DESCRIPTION
## Summary

Adds real per-SKU scoring breakdown to the API and modal UI, merges AKS panels into a single cleaner accordion, and improves overall modal layout.

### Changes

**Backend (scoring + API)**
- `scoring.py`: `score_sku()` now returns a 4-tuple including a `breakdown` list with each scoring factor's label, points, and whether it was applied
- `models.py`: Added `score_breakdown` field to `SkuRecommendation`, serialised as `scoreBreakdown`
- `service.py`: Updated to pass breakdown through to the model

**Frontend (JS)**
- Merged "AKS Node Pool Eligibility" and "AKS Score Details" into a single **"AKS Assessment"** accordion panel, expanded by default
- Pool type moved inline with status badge (e.g. "Eligible (system pool)")
- Breakdown badges rendered in a flex-wrap container with proper spacing instead of a cramped label row
- Separate "AKS Score" column in the table (no longer a fallback in Confidence column)
- Detail button click handler uses event delegation to survive DataTable re-sorting
- Added real per-SKU breakdown badges: green (applied bonus), red (applied penalty), grey (not applied)

**Documentation**
- Complete README rewrite to match current features

**Tests**
- All `score_sku()` unpacking updated from 3-tuple to 4-tuple
- Added assertions for breakdown structure
- All 48 tests passing

> **Note:** The shared `sku-detail-modal.js` in `az-scout` core also has a small companion change (prependSections support + spacing) that should be merged separately.